### PR TITLE
Implement https://github.com/Larkinabout/fvtt-token-action-hud-pf2e/issues/107

### DIFF
--- a/scripts/roll-handler.js
+++ b/scripts/roll-handler.js
@@ -37,6 +37,63 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
         }
 
         /**
+         * Handle action hover
+         * @override
+         * @param {object} event
+         * @param {string} encodedValue
+         */
+        async handleActionHover (event, encodedValue) {
+            const types = ['elementalBlast', 'action', 'feat', 'item', 'spell', 'familiarAttack', 'strike']
+            const [actionType, actionData] = encodedValue.replaceAll("%3E", ">").split('|')
+
+            if (!types.includes(actionType)) return
+
+            if (!this.actor) return
+
+            const item = (() => {
+                switch (actionType) {
+                case 'elementalBlast':
+                    const [blastId, blastElement, blastValue, blastType] = actionData.split('>')
+                    const blast = coreModule.api.Utils.getItem(this.actor, blastId)
+                    const blastItem = blast.rules.find(r => r.value.element == blastElement)
+                    return blastItem
+                    break
+                case 'spell':
+                    const [spellcastingEntry, rank, spellId] = actionData.split('>')
+                    const spellItem = coreModule.api.Utils.getItem(this.actor, spellId)
+                    return spellItem
+                    break
+                case 'strike':
+                    const [strikeId, strikeName, strikeValue, strikeType] = actionData.split('>')
+                    if (strikeId === 'xxPF2ExUNARMEDxx') {
+                        const strikeItem = this.actor.system.actions.find(a => a.item.id === 'xxPF2ExUNARMEDxx').item
+                        return strikeItem
+                    }
+                    const strikeItem = coreModule.api.Utils.getItem(this.actor, strikeId)
+                    return strikeItem
+                    break
+                case 'familiarAttack':
+                    const attackItem = this.actor.system.attack
+                    return attackItem
+                    break
+                default:
+                    const actionId = actionData.split('>', 1)[0]
+                    const actionItem = coreModule.api.Utils.getItem(this.actor, actionId)
+                    return actionItem
+                    break
+                }
+            })();
+
+            if (!item) return
+
+            if (event.type === 'mouseenter') {
+                Hooks.call('tokenActionHudSystemActionHoverOn', event, item)
+            } else {
+                Hooks.call('tokenActionHudSystemActionHoverOff', event, item)
+            }
+        }
+
+        /**
          * Set roll options
          */
         #setRollOptions () {

--- a/scripts/roll-handler.js
+++ b/scripts/roll-handler.js
@@ -44,45 +44,44 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
          */
         async handleActionHover (event, encodedValue) {
             const types = ['elementalBlast', 'action', 'feat', 'item', 'spell', 'familiarAttack', 'strike']
-            const [actionType, actionData] = encodedValue.replaceAll("%3E", ">").split('|')
+            const [actionType, actionData] = decodeURIComponent(encodedValue).split('|')
 
             if (!types.includes(actionType)) return
 
             if (!this.actor) return
 
-            const item = (() => {
-                switch (actionType) {
-                case 'elementalBlast':
-                    const [blastId, blastElement, blastValue, blastType] = actionData.split('>')
-                    const blast = coreModule.api.Utils.getItem(this.actor, blastId)
-                    const blastItem = blast.rules.find(r => r.value.element == blastElement)
-                    return blastItem
-                    break
-                case 'spell':
-                    const [spellcastingEntry, rank, spellId] = actionData.split('>')
-                    const spellItem = coreModule.api.Utils.getItem(this.actor, spellId)
-                    return spellItem
-                    break
-                case 'strike':
-                    const [strikeId, strikeName, strikeValue, strikeType] = actionData.split('>')
-                    if (strikeId === 'xxPF2ExUNARMEDxx') {
-                        const strikeItem = this.actor.system.actions.find(a => a.item.id === 'xxPF2ExUNARMEDxx').item
-                        return strikeItem
-                    }
-                    const strikeItem = coreModule.api.Utils.getItem(this.actor, strikeId)
+            let item
+            switch (actionType) {
+            case 'elementalBlast':
+                const [blastId, blastElement, blastValue, blastType] = actionData.split('>')
+                const blast = coreModule.api.Utils.getItem(this.actor, blastId)
+                const blastItem = blast.rules.find(r => r.value.element == blastElement)
+                item = blastItem
+                break
+            case 'spell':
+                const [spellcastingEntry, rank, spellId] = actionData.split('>')
+                const spellItem = coreModule.api.Utils.getItem(this.actor, spellId)
+                item = spellItem
+                break
+            case 'strike':
+                const [strikeId, strikeName, strikeValue, strikeType] = actionData.split('>')
+                if (strikeId === 'xxPF2ExUNARMEDxx') {
+                    const strikeItem = this.actor.system.actions.find(a => a.item.id === 'xxPF2ExUNARMEDxx').item
                     return strikeItem
-                    break
-                case 'familiarAttack':
-                    const attackItem = this.actor.system.attack
-                    return attackItem
-                    break
-                default:
-                    const actionId = actionData.split('>', 1)[0]
-                    const actionItem = coreModule.api.Utils.getItem(this.actor, actionId)
-                    return actionItem
-                    break
                 }
-            })();
+                const strikeItem = coreModule.api.Utils.getItem(this.actor, strikeId)
+                item = strikeItem
+                break
+            case 'familiarAttack':
+                const attackItem = this.actor.system.attack
+                item = attackItem
+                break
+            default:
+                const actionId = actionData.split('>', 1)[0]
+                const actionItem = coreModule.api.Utils.getItem(this.actor, actionId)
+                item = actionItem
+                break
+            }
 
             if (!item) return
 


### PR DESCRIPTION
Two items of note:

1. The way Elemental Blast is implemented in PF2e is by using a single attack for all blast options, with handling done by Rules Elements. This means that fvtt-token-action-hud-pf2e can't return a normal item for this kind of attack. Instead, I have opted to return the specific ActiveEffectLike Rules Element for the element that is being used when activating Elemental Blast. This Rules Element contains the range, but it is in a non-standard location that tactical-grid (and any other modules) will have to handle.
2. Familiar Attacks do not have a range specified. It would be best for tactical-grid (and any other modules) to handle this case. It'd probably be best to look for the following two slugs, which are present on Familiar Attacks, to verify that a familiar attack item was returned by this feature: { "slug": "attack-roll", "modifiers": [ { "slug": "master-level" } ] }