### PR TITLE
Corrected weapon trait option use with npc and hazard actors

### DIFF
--- a/scripts/action-handler.js
+++ b/scripts/action-handler.js
@@ -1455,7 +1455,14 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                 const strikeId = `${strike.item.id}-${strike.slug}`
                 const strikeGroupId = `strikes+${strikeId}`
                 let strikeGroupName = strike.label
-                if (this.showStrikeNames && this.showStrikeTraits && strike.weaponTraits.length) {
+                if (this.actor.type === 'hazard' || this.actor.type === 'npc') {
+                    if (this.showStrikeNames && this.showStrikeTraits && strike.traits.length) {
+                        strikeGroupName += ' - '
+                        strike.traits.forEach((t) => {
+                            strikeGroupName += '[' + t.label + ']'
+                        })
+                    }
+                } else if (this.showStrikeNames && this.showStrikeTraits && strike.weaponTraits.length) {
                     strikeGroupName += ' - '
                     strike.weaponTraits.forEach((t) => {
                         strikeGroupName += '[' + t.label + ']'


### PR DESCRIPTION
Corrected an issue with using the weapon trait option that broke on npc and hazard actors. These actors use 'traits' instead of 'weaponTraits'.