### PR TITLE
Implement workaround for https://github.com/Larkinabout/fvtt-token-action-hud-pf2e/issues/129

### DIFF
--- a/languages/br.json
+++ b/languages/br.json
@@ -7,7 +7,6 @@
     "tokenActionHud.pf2e.equipment": "Equipamento",
     "tokenActionHud.pf2e.heroAction": "Hero Action",
     "tokenActionHud.pf2e.heroActions": "Hero Actions",
-    "tokenActionHud.pf2e.initiativeAlreadyRolled": "Iniciativa já lançada",
     "tokenActionHud.pf2e.inventory": "Inventário",
     "tokenActionHud.pf2e.noAmmo": "Sem Munição",
     "tokenActionHud.pf2e.otherConditions": "Outro",

--- a/languages/cn.json
+++ b/languages/cn.json
@@ -7,7 +7,6 @@
     "tokenActionHud.pf2e.equipment": "装备",
     "tokenActionHud.pf2e.heroAction": "Hero Action",
     "tokenActionHud.pf2e.heroActions": "Hero Actions",
-    "tokenActionHud.pf2e.initiativeAlreadyRolled": "先攻已投掷",
     "tokenActionHud.pf2e.inventory": "库存",
     "tokenActionHud.pf2e.noAmmo": "无弹药",
     "tokenActionHud.pf2e.otherConditions": "其他",

--- a/languages/de.json
+++ b/languages/de.json
@@ -7,7 +7,6 @@
     "tokenActionHud.pf2e.equipment": "Ausrüstung",
     "tokenActionHud.pf2e.heroAction": "Hero Action",
     "tokenActionHud.pf2e.heroActions": "Hero Actions",
-    "tokenActionHud.pf2e.initiativeAlreadyRolled": "Initiative bereits geworfen",
     "tokenActionHud.pf2e.inventory": "Inventar",
     "tokenActionHud.pf2e.noAmmo": "Keine Munition",
     "tokenActionHud.pf2e.otherConditions": "Andere",

--- a/languages/en.json
+++ b/languages/en.json
@@ -7,7 +7,6 @@
     "tokenActionHud.pf2e.equipment": "Equipment",
     "tokenActionHud.pf2e.heroAction": "Hero Action",
     "tokenActionHud.pf2e.heroActions": "Hero Actions",
-    "tokenActionHud.pf2e.initiativeAlreadyRolled": "Initiative already rolled",
     "tokenActionHud.pf2e.inventory": "Inventory",
     "tokenActionHud.pf2e.noAmmo": "No Ammo",
     "tokenActionHud.pf2e.otherConditions": "Other",

--- a/languages/es.json
+++ b/languages/es.json
@@ -7,7 +7,6 @@
     "tokenActionHud.pf2e.equipment": "Equipo",
     "tokenActionHud.pf2e.heroAction": "Hero Action",
     "tokenActionHud.pf2e.heroActions": "Hero Actions",
-    "tokenActionHud.pf2e.initiativeAlreadyRolled": "Iniciativa ya lanzada",
     "tokenActionHud.pf2e.inventory": "Inventario",
     "tokenActionHud.pf2e.noAmmo": "Sin munición",
     "tokenActionHud.pf2e.otherConditions": "Otro",

--- a/languages/fr.json
+++ b/languages/fr.json
@@ -7,7 +7,6 @@
     "tokenActionHud.pf2e.equipment": "Équipement",
     "tokenActionHud.pf2e.heroAction": "Hero Action",
     "tokenActionHud.pf2e.heroActions": "Hero Actions",
-    "tokenActionHud.pf2e.initiativeAlreadyRolled": "Initiative déjà lancée",
     "tokenActionHud.pf2e.inventory": "Inventaire",
     "tokenActionHud.pf2e.noAmmo": "Pas de munition",
     "tokenActionHud.pf2e.otherConditions": "Autre",

--- a/languages/it.json
+++ b/languages/it.json
@@ -7,7 +7,6 @@
     "tokenActionHud.pf2e.equipment": "Attrezzatura",
     "tokenActionHud.pf2e.heroAction": "Hero Action",
     "tokenActionHud.pf2e.heroActions": "Hero Actions",
-    "tokenActionHud.pf2e.initiativeAlreadyRolled": "Iniziativa già tirata",
     "tokenActionHud.pf2e.inventory": "Inventario",
     "tokenActionHud.pf2e.noAmmo": "Nessuna Munizione",
     "tokenActionHud.pf2e.otherConditions": "Altro",

--- a/languages/ja.json
+++ b/languages/ja.json
@@ -7,7 +7,6 @@
     "tokenActionHud.pf2e.equipment": "装備",
     "tokenActionHud.pf2e.heroAction": "Hero Action",
     "tokenActionHud.pf2e.heroActions": "Hero Actions",
-    "tokenActionHud.pf2e.initiativeAlreadyRolled": "イニシアチブはすでに振られています",
     "tokenActionHud.pf2e.inventory": "インベントリ",
     "tokenActionHud.pf2e.noAmmo": "弾薬なし",
     "tokenActionHud.pf2e.otherConditions": "他の",

--- a/languages/ko.json
+++ b/languages/ko.json
@@ -7,7 +7,6 @@
     "tokenActionHud.pf2e.equipment": "장비",
     "tokenActionHud.pf2e.heroAction": "Hero Action",
     "tokenActionHud.pf2e.heroActions": "Hero Actions",
-    "tokenActionHud.pf2e.initiativeAlreadyRolled": "이미 초기화표가 굴러갔습니다",
     "tokenActionHud.pf2e.inventory": "인벤토리",
     "tokenActionHud.pf2e.noAmmo": "탄약 없음",
     "tokenActionHud.pf2e.otherConditions": "다른",

--- a/languages/pl.json
+++ b/languages/pl.json
@@ -7,7 +7,6 @@
     "tokenActionHud.pf2e.equipment": "Sprzęt",
     "tokenActionHud.pf2e.heroAction": "Hero Action",
     "tokenActionHud.pf2e.heroActions": "Hero Actions",
-    "tokenActionHud.pf2e.initiativeAlreadyRolled": "Inicjatywa już rzucona",
     "tokenActionHud.pf2e.inventory": "Inwentarz",
     "tokenActionHud.pf2e.noAmmo": "Brak amunicji",
     "tokenActionHud.pf2e.otherConditions": "Inny",

--- a/languages/zh-tw.json
+++ b/languages/zh-tw.json
@@ -7,7 +7,6 @@
     "tokenActionHud.pf2e.equipment": "裝備",
     "tokenActionHud.pf2e.heroAction": "Hero Action",
     "tokenActionHud.pf2e.heroActions": "Hero Actions",
-    "tokenActionHud.pf2e.initiativeAlreadyRolled": "先攻已擲出",
     "tokenActionHud.pf2e.inventory": "庫存",
     "tokenActionHud.pf2e.noAmmo": "無彈藥",
     "tokenActionHud.pf2e.otherConditions": "其他",

--- a/scripts/roll-handler.js
+++ b/scripts/roll-handler.js
@@ -380,7 +380,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
          */
         async #rollInitiative (actor, actionId) {
             if (actor.inCombat && actor.combatant?.initiative) {
-                coreModule.api.Logger.info(coreModule.api.Utils.i18n('tokenActionHud.pf2e.initiativeAlreadyRolled'), true)
+                coreModule.api.Logger.info(game.i18n.format('PF2E.Encounter.AlreadyRolled', { actor: actor.name }), true)
             } else {
                 await actor.update({ 'system.attributes.initiative.statistic': actionId })
 
@@ -620,7 +620,6 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
          * @param {string} actionId The action id
          */
         async #performVersatileOption (actor, actionId) {
-            // itemId, slug, selection
             const [itemId, slug, selection] = decodeURIComponent(actionId).split('>', 3)
 
             const action = actor.system.actions
@@ -632,7 +631,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
 
             await toggleWeaponTrait({ weapon, trait: 'versatile', selection })
 
-            // Adapted from pf2e.js
+            // Adapted from pf2e
             async function toggleWeaponTrait ({ weapon, trait, selection }) {
                 if (weapon.system.traits.toggles[trait].selection === selection) return
 


### PR DESCRIPTION
 - Implemented an ugly workaround for an unknown issue stemming from calling "await entity.getChatData()" for the "spell" actionType.
- Replaced TAHPF2e's "initiative already rolled" localization with built-in PF2e system localization.
- Minor code cleanup.