### PR TITLE
Fix issue with right-clicking on spells

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/*
 scripts/token-action-hud-pf2e.min.js
+scripts/token-action-hud-pf2e.min.js.map

--- a/scripts/action-handler.js
+++ b/scripts/action-handler.js
@@ -1411,7 +1411,15 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                 const tooltip = await this.#getTooltip(actionType, tooltipData)
 
                 // Create group data
-                strikeGroupData = { id: strikeGroupId, name: strikeGroupName, listName: strikeGroupListName, type: 'system-derived', settings: { showTitle }, tooltip }
+                strikeGroupData = {
+                    id: strikeGroupId,
+                    name: strikeGroupName,
+                    listName: strikeGroupListName,
+                    type: 'system-derived',
+                    settings: { showTitle },
+                    tooltip
+                }
+                
                 if (this.showStrikeImages) {
                     strikeGroupData.settings.image = image
                 }
@@ -1574,9 +1582,17 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                 const showTitle = this.showStrikeNames
                 const tooltipData = await this.#getTooltipData(strike, actionType)
                 const tooltip = await this.#getTooltip(actionType, tooltipData)
+
                 // Create group data
-                strikeGroupData = { id: strikeGroupId, name: strikeGroupName, listName: strikeGroupListName, type: 'system-derived', settings: { showTitle }, tooltip }
-                if (this.showStrikeImages) { strikeGroupData.settings.image = image }
+                strikeGroupData = {
+                    id: strikeGroupId,
+                    name: strikeGroupName,
+                    listName: strikeGroupListName,
+                    type: 'system-derived',
+                    settings: { showTitle },
+                    tooltip
+                }
+                if (this.showStrikeImages) strikeGroupData.settings.image = image
                 if (typeof strikeGroupData.settings.sort === 'undefined' && coreModule.api.Utils.getSetting('sortActions')) strikeGroupData.settings.sort = false
 
                 // Add group to action list
@@ -1596,8 +1612,8 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                                     name,
                                     listName: `${strikeGroupListName}: ${name}`,
                                     encodedValue: ['strikeAuxiliaryAction', id].join(this.delimiter),
-                                    icon1: this.#getActionIcon(auxiliaryAction.glyph),
-                                    cssClass: this.#getActionCss({ selected: (modularOption === modularSelection) })
+                                    cssClass: this.#getActionCss({ selected: (modularOption === modularSelection) }),
+                                    icon1: this.#getActionIcon(auxiliaryAction.glyph)
                                 }
                             })
                         } else {
@@ -1730,7 +1746,6 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                                 actions.push({
                                     id,
                                     name,
-
                                     listName: `${usageGroupListName}: ${name}`,
                                     encodedValue: [actionType, id].join(this.delimiter)
                                 })
@@ -2014,9 +2029,6 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
 
             if (!chatData) return ''
 
-            // console.log(entity)
-            // console.log(actionType)
-
             switch (actionType) {
             case 'item':
                 return {
@@ -2114,14 +2126,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
 
             if (!description && !tagsHtml && !modifiersHtml) return name
 
-            /*  const tooltipHtml = await TextEditor.enrichHTML(
-                `<div>${nameHtml}${headerTags}${description}${propertiesHtml}</div>`,
-                { async: true }
-            ) */
-
-            const tooltipHtml = `<div>${nameHtml}${headerTags}${description}${propertiesHtml}</div>`
-
-            return await TextEditor.enrichHTML(tooltipHtml, { async: true })
+            return `<div>${nameHtml}${headerTags}${description}${propertiesHtml}</div>`
         }
 
         /**

--- a/scripts/roll-handler.js
+++ b/scripts/roll-handler.js
@@ -446,7 +446,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
             const [spellbookId, level, spellId, expend] = decodeURIComponent(actionId).split('>', 4)
 
             if (this.isRenderItem()) {
-                return this.doRenderItem(actor, spellId)
+                return this.renderItem(actor, spellId)
             }
 
             const spellbook = actor.items.get(spellbookId)
@@ -518,7 +518,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                 .find(strike => strike.item.id === itemId && strike.slug === slug)
 
             if (this.isRenderItem() && strike.item?.id !== 'xxPF2ExUNARMEDxx') {
-                return this.doRenderItem(actor, strike.item.id)
+                return this.renderItem(actor, strike.item.id)
             }
 
             let altUsage
@@ -569,7 +569,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
             if (!strike) return
 
             if (strike.origin && this.isRenderItem()) {
-                this.doRenderItem(actor, strike.origin.id)
+                this.renderItem(actor, strike.origin.id)
             } else {
                 strike.auxiliaryActions[strikeType]?.execute({ selection })
             }


### PR DESCRIPTION
Fix issue with right-clicking on spells caused by core function rename of doRenterItem() to renderItem()