### PR TITLE
Fix event type check so tokenActionHudSystemActionHoverOn hook is called.

### DIFF
--- a/scripts/roll-handler.js
+++ b/scripts/roll-handler.js
@@ -156,7 +156,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
 
             if (!item) return
 
-            if (event.type === 'mouseenter') {
+            if (event.type === 'pointerenter') {
                 Hooks.call('tokenActionHudSystemActionHoverOn', event, item)
             } else {
                 Hooks.call('tokenActionHudSystemActionHoverOff', event, item)


### PR DESCRIPTION
fix (roll-handler.js): Fixed event type check from 'mouseenter' to 'pointerenter' so the Hook is actually called.